### PR TITLE
Clean up package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "homepage": "https://github.com/porchdotcom/nock-back-mocha#readme",
   "scripts": {
-    "test": "./node_modules/.bin/mocha",
-    "lint": "./node_modules/.bin/eslint ."
+    "test": "mocha",
+    "lint": "eslint ."
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
npm bootstraps the PATH with everything in node_modules/.bin so you
don't have to specify the full path
